### PR TITLE
Add repository condition to release job

### DIFF
--- a/.github/workflows/build-nmse.yml
+++ b/.github/workflows/build-nmse.yml
@@ -187,7 +187,7 @@ jobs:
     runs-on: windows-latest
     needs: [build-linux, build-macos]
     # Only require build-linux (which implies build-win) to succeed.
-    if: always() && needs.build-linux.result == 'success'
+    if: always() && needs.build-linux.result == 'success' && github.repository == 'vectorcmdr/NMSE'
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Added vectorcmdr/NMSE repo as a build requirement so it won't auto-build on forks

# Pull Request

## 🧩 Summary

Prevents releases on forks by adding a repo requirement to the release job. It still allows manual triggers so that build artifacts can be still made for testing.

## ✅ Checklist

- [X] I have read the **Contributor Guidelines** in [`CONTRIBUTING.md`](https://github.com/vectorcmdr/NMSE/blob/main/.github/CONTRIBUTING.md)
- [X] My changes follow the project style and conventions
- [X] I have not introduced external packages or libraries
- [NA] I have added localisation to UI strings
- [NA] I added/updated tests (if applicable)
- [NA] All existing and new tests pass
- [NA] I have updated documentation as needed

## 🧪 Testing

Tested that it does not make a release on a forked repo but cannot verify it on the main repo.